### PR TITLE
add OWNERS_ALIASES for knative-build

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- mattmoor
-- ImJasonH
-- shashwathi
+- build-approvers
+
+reviewers:
+- build-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,23 @@
+aliases:
+  build-approvers:
+  - alanfx
+  - mgencur
+  - mvinkler
+  - bbrowning
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - vdemeester
+  - evanchooly
+  - arilivigni
+  build-reviewers:
+  - alanfx
+  - mgencur
+  - mvinkler
+  - bbrowning
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - vdemeester
+  - evanchooly
+  - arilivigni


### PR DESCRIPTION
This PR adds OWNERS_ALIASES for knative-build similar way as for [knative-serving](https://github.com/openshift/knative-serving/blob/master/OWNERS_ALIASES).