### PR TITLE
Generate Dockerfiles via script - release-0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,12 @@
 
 CGO_ENABLED=0
 GOOS=linux
-CORE_IMAGES=./cmd/controller/ ./cmd/creds-init ./cmd/git-init/ ./cmd/nop ./cmd/webhook
+CORE_IMAGES=./cmd/controller/ ./cmd/nop ./cmd/webhook
+CORE_IMAGES_WITH_GIT=./cmd/creds-init ./cmd/git-init/
 TEST_IMAGES=./test/panic/
 
 install:
-	go install $(CORE_IMAGES)
+	go install $(CORE_IMAGES) $(CORE_IMAGES_WITH_GIT)
 .PHONY: install
 
 test-install:
@@ -19,6 +20,7 @@ test-e2e:
 
 # Generate Dockerfiles used by ci-operator. The files need to be committed manually.
 generate-dockerfiles:
-	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-images $(CORE_IMAGES)
-	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-test-images $(TEST_IMAGES)
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/Dockerfile.in openshift/ci-operator/knative-images $(CORE_IMAGES)
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/Dockerfile-git.in openshift/ci-operator/knative-images $(CORE_IMAGES_WITH_GIT)
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/Dockerfile.in openshift/ci-operator/knative-test-images $(TEST_IMAGES)
 .PHONY: generate-dockerfiles

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,23 @@
 
 CGO_ENABLED=0
 GOOS=linux
+CORE_IMAGES=./cmd/controller/ ./cmd/creds-init ./cmd/git-init/ ./cmd/nop ./cmd/webhook
+TEST_IMAGES=./test/panic/
 
 install:
-	go install ./cmd/controller/ ./cmd/creds-init ./cmd/git-init/ ./cmd/nop ./cmd/webhook
+	go install $(CORE_IMAGES)
 .PHONY: install
 
 test-install:
-	go install ./test/panic/
+	go install $(TEST_IMAGES)
 .PHONY: test-install
 
 test-e2e:
 	sh openshift/e2e-tests-openshift.sh
 .PHONY: test-e2e
+
+# Generate Dockerfiles used by ci-operator. The files need to be committed manually.
+generate-dockerfiles:
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-images $(CORE_IMAGES)
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-test-images $(TEST_IMAGES)
+.PHONY: generate-dockerfiles

--- a/openshift/ci-operator/Dockerfile-git.in
+++ b/openshift/ci-operator/Dockerfile-git.in
@@ -3,5 +3,5 @@ FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 RUN yum install -y git openssh-client
 
-ADD creds-init /usr/bin/creds-init
-ENTRYPOINT ["/usr/bin/creds-init"]
+ADD ${bin} /usr/bin/${bin}
+ENTRYPOINT ["/usr/bin/${bin}"]

--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
-ADD nop /usr/bin/nop
-ENTRYPOINT ["/usr/bin/nop"]
+ADD ${bin} /usr/bin/${bin}
+ENTRYPOINT ["/usr/bin/${bin}"]

--- a/openshift/ci-operator/generate-dockerfiles.sh
+++ b/openshift/ci-operator/generate-dockerfiles.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -x
+
+function generate_dockefiles() {
+  local target_dir=$1; shift
+  for img in $@; do
+    local image_base=$(basename $img)
+    mkdir -p $target_dir/$image_base
+    bin=$image_base envsubst < openshift/ci-operator/Dockerfile.in > $target_dir/$image_base/Dockerfile
+  done
+}
+
+generate_dockefiles $@

--- a/openshift/ci-operator/generate-dockerfiles.sh
+++ b/openshift/ci-operator/generate-dockerfiles.sh
@@ -3,11 +3,12 @@
 set -x
 
 function generate_dockefiles() {
-  local target_dir=$1; shift
+  local dockerfile_in=$1;
+  local target_dir=$2; shift; shift
   for img in $@; do
     local image_base=$(basename $img)
     mkdir -p $target_dir/$image_base
-    bin=$image_base envsubst < openshift/ci-operator/Dockerfile.in > $target_dir/$image_base/Dockerfile
+    bin=$image_base envsubst < $dockerfile_in > $target_dir/$image_base/Dockerfile
   done
 }
 

--- a/openshift/ci-operator/knative-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/controller/Dockerfile
@@ -1,5 +1,5 @@
-FROM gcr.io/distroless/base:latest
-LABEL maintainer="mgencur@redhat.com"
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD controller /usr/bin/controller
 ENTRYPOINT ["/usr/bin/controller"]

--- a/openshift/ci-operator/knative-images/creds-init/Dockerfile
+++ b/openshift/ci-operator/knative-images/creds-init/Dockerfile
@@ -1,5 +1,5 @@
-FROM gcr.io/distroless/base:latest
-LABEL maintainer="mgencur@redhat.com"
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD creds-init /usr/bin/creds-init
 ENTRYPOINT ["/usr/bin/creds-init"]

--- a/openshift/ci-operator/knative-images/git-init/Dockerfile
+++ b/openshift/ci-operator/knative-images/git-init/Dockerfile
@@ -1,5 +1,5 @@
-FROM gcr.io/distroless/base:latest
-LABEL maintainer="mgencur@redhat.com"
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD git-init /usr/bin/git-init
 ENTRYPOINT ["/usr/bin/git-init"]

--- a/openshift/ci-operator/knative-images/git-init/Dockerfile
+++ b/openshift/ci-operator/knative-images/git-init/Dockerfile
@@ -1,5 +1,7 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
+RUN yum install -y git openssh-client
+
 ADD git-init /usr/bin/git-init
 ENTRYPOINT ["/usr/bin/git-init"]

--- a/openshift/ci-operator/knative-images/webhook/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook/Dockerfile
@@ -1,5 +1,5 @@
-FROM gcr.io/distroless/base:latest
-LABEL maintainer="mgencur@redhat.com"
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD webhook /usr/bin/webhook
 ENTRYPOINT ["/usr/bin/webhook"]

--- a/openshift/ci-operator/knative-test-images/panic/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/panic/Dockerfile
@@ -1,5 +1,5 @@
-FROM gcr.io/distroless/base:latest
-LABEL maintainer="mgencur@redhat.com"
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD panic /usr/bin/panic
 ENTRYPOINT ["/usr/bin/panic"]


### PR DESCRIPTION
* Use registry.svc.ci.openshift.org/openshift/origin-v3.11:base as the
base image. The FROM clause is ignored by ci-operator during the actual
build and is replaced by an image from ci-operator's config. Anyway,
it's replaced with the same image name so here we only make sure the
user knows what the base image is.
(this update comes after this change: https://github.com/openshift/release/commit/7da82d875c6e29dd58637223b3cefb3044945665 )